### PR TITLE
feat: add support for custom color fn

### DIFF
--- a/dist/cannon-es-debugger.d.ts
+++ b/dist/cannon-es-debugger.d.ts
@@ -1,10 +1,11 @@
 declare module "cannon-es-debugger" {
-    import { Shape } from 'cannon-es';
+    import { Shape, ShapeType } from 'cannon-es';
     import { Mesh } from 'three';
     import type { Body } from 'cannon-es';
     import type { Scene, Color } from 'three';
+    type ColorFn = (shape: ShapeType) => string | number | Color;
     export type DebugOptions = {
-        color?: string | number | Color;
+        color?: string | number | Color | ColorFn;
         scale?: number;
         onInit?: (body: Body, mesh: Mesh, shape: Shape) => void;
         onUpdate?: (body: Body, mesh: Mesh, shape: Shape) => void;


### PR DESCRIPTION
Fixes #18 

Example
```js
cannonDebugger(scene, world.bodies, {
  color: (shape) => {
    switch (shape) {
      case CANNON.SHAPE_TYPES.BOX:
      case CANNON.SHAPE_TYPES.CONVEXPOLYHEDRON:
        return 0x0000ff;
      case CANNON.SHAPE_TYPES.TRIMESH:
      case CANNON.SHAPE_TYPES.HEIGHTFIELD:
        return 0xff0000;
      default:
        return 0x00ff00;
    }
  },
});

```