### PR TITLE
🔫 Remove autoUpdate option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 This is a debugger for use with [cannon-es](https://github.com/pmndrs/cannon-es). It was adapted from the [original cannon.js debugger](https://github.com/schteppe/cannon.js/blob/master/tools/threejs/CannonDebugRenderer.js) written by Stefan Hedman [@schteppe](https://github.com/schteppe).
 
-**Note:** This debugger is implemented within [use-cannon](https://github.com/pmndrs/use-cannon#debug) directly.
+**Note:** This debugger is included in [use-cannon](https://github.com/pmndrs/use-cannon#debug) directly.
 
 ### Installation
 
@@ -18,25 +18,36 @@ yarn add three cannon-es
 
 ### Usage
 
-Give `cannon-es-debugger` references to your Three scene object and Cannon physics bodies:
+Give `cannon-es-debugger` references to your three.js scene object and cannon-es world:
 
 ```js
 import { Scene } from 'three'
 import { World } from 'cannon-es'
-import cannonDebugger from 'cannon-es-debugger'
+import CannonDebugger from 'cannon-es-debugger'
 
 const scene = new Scene()
 const world = new World()
-cannonDebugger(scene, world.bodies, options)
+const cannonDebugger = new CannonDebugger(scene, world, {
+  // options...
+})
+
+// ...
+
+function animate() {
+  requestAnimationFrame(animate)
+
+  world.step(timeStep) // Update cannon-es physics
+  cannonDebugger.update() // Update the CannonDebugger meshes
+  renderer.render(scene, camera) // Render the three.js scene
+}
+animate()
 ```
 
-New meshes with wireframe textures will be generated from your physics body geometries and added into the scene. A mesh will be created for every shape in the physics body. The position of the meshes will be synched with the Cannon physics body simulation on every animation frame.
+New meshes with wireframe material will be generated from your physics body shapes and added into the scene. The position of the meshes will be synched with the Cannon physics body simulation on every animation frame.
 
 ### API
 
-The available properties of the `options` object are listed below.
-
-```typescript
+```ts
 import type { Scene, Color } from 'three'
 import type { Body } from 'cannon-es'
 
@@ -45,20 +56,23 @@ type DebugOptions = {
   scale?: number
   onInit?: (body: Body, mesh: Mesh, shape: Shape) => void
   onUpdate?: (body: Body, mesh: Mesh, shape: Shape) => void
-  autoUpdate?: Boolean
 }
 
-export default function cannonDebugger(scene: Scene, bodies: Body[], options: DebugOptions): void
+export default class CannonDebugger {
+  constructor(scene: Scene, world: World, options: DebugOptions): void
+
+  update(): void
+}
 ```
+
+The available properties of the `options` object are:
 
 - **`color`** - a [Three Color](https://threejs.org/docs/#api/en/math/Color) argument that sets the wireframe color, defaults to `0x00ff00`
 
-- **`scale`** - scale factor, defaults to 1
+- **`scale`** - scale factor for all the wireframe meshes, defaults to 1
 
 - **`onInit`** - callback function that runs once, right after a new wireframe mesh is added
 
 - **`onUpdate`** - callback function that runs on every subsequent animation frame
 
-- **`autoUpdate`** - wheter or not the debugger should update by itself (default: `true`)
-
-If you set `autoUpdate: false`, then you can use the `update()` method included in the returned object to update the debugger manually.
+The `update()` method needs to be called in a `requestAnimationFrame` loop to keep updating the wireframe meshes after the bodies have been updated.


### PR DESCRIPTION
Fixes #21 

Having an internal raf loop has resulted in being problematic since the wireframe meshes were not in sync with the bodies. Also [this behaviour appears to be confusing for cannon.js users](https://github.com/pmndrs/cannon-es-debugger/issues/21).

Moreover, [not even `use-cannon` is actually using this feature](https://github.com/pmndrs/use-cannon/blob/a3281b5ad271163db4d35a8453bdccd9960811ce/src/Debug.tsx#L51).

Makes sense to remove it completely.

I also went ahead and updated the signature to match the original CannonDebugRenderer.