### PR TITLE
Example update

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
   </head>
   <body>
     <div class="page-title">Press the <span>d</span> key to toggle the debugger</div>
+    <script async src="https://ga.jspm.io/npm:es-module-shims@1.3.6/dist/es-module-shims.js"></script>
     <script type="importmap">
       {
         "imports": {

--- a/readme.md
+++ b/readme.md
@@ -78,3 +78,11 @@ The available properties of the `options` object are:
 - **`onUpdate`** - callback function that runs on every subsequent animation frame
 
 The `update()` method needs to be called in a `requestAnimationFrame` loop to keep updating the wireframe meshes after the bodies have been updated.
+
+### EXAMPLE
+
+You can run an example by serving the `index`. An easy way to do this is with [serve](https://github.com/vercel/serve).
+
+```js
+npx serve
+```


### PR DESCRIPTION
This PR:
- Adds an import-map shim to the example so Firefox works. (I know it's not a big deal, but this tripped me up for a minute.)
- Adds a note in the Readme on how to use the example.