### PR TITLE
Bump three dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 node_modules
-yarn-error.log
+*.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+yarn-error.log

--- a/dist/cannon-es-debugger.d.ts
+++ b/dist/cannon-es-debugger.d.ts
@@ -1,8 +1,15 @@
 declare module "cannon-es-debugger" {
     import { Shape } from 'cannon-es';
     import { Mesh } from 'three';
-    import type { Body, World } from 'cannon-es';
-    import type { Scene, Color } from 'three';
+    import type { Body } from 'cannon-es';
+    import type { Color } from 'three';
+    interface Scene {
+        add: (mesh: Mesh) => void;
+        remove: (mesh: Mesh) => void;
+    }
+    interface World {
+        bodies: Body[];
+    }
     export type DebugOptions = {
         color?: string | number | Color;
         scale?: number;

--- a/package.json
+++ b/package.json
@@ -45,13 +45,13 @@
     "@babel/preset-typescript": "^7.16.5",
     "@rollup/plugin-babel": "^5.3.0",
     "@rollup/plugin-node-resolve": "^13.1.1",
-    "@types/three": "^0.135.0",
+    "@types/three": "^0.137.0",
     "cannon-es": "^0.18.0",
     "prettier": "^2.5.1",
     "rimraf": "^3.0.2",
     "rollup": "^2.62.0",
     "serve": "^13.0.2",
-    "three": "^0.136.0",
+    "three": "^0.137.0",
     "typescript": "^4.5.4"
   }
 }

--- a/src/cannon-es-debugger.ts
+++ b/src/cannon-es-debugger.ts
@@ -21,8 +21,17 @@ import {
   BufferGeometry,
   Float32BufferAttribute,
 } from 'three'
-import type { Body, World } from 'cannon-es'
-import type { Scene, Color } from 'three'
+import type { Body } from 'cannon-es'
+import type { Color } from 'three'
+
+interface Scene {
+  add: (mesh: Mesh) => void
+  remove: (mesh: Mesh) => void
+}
+
+interface World {
+  bodies: Body[]
+}
 
 type ComplexShape = Shape & { geometryId?: number }
 export type DebugOptions = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1110,10 +1110,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/three@^0.135.0":
-  version "0.135.0"
-  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.135.0.tgz#db7f9d9699b60aba844fc5b2893adf6dd6811665"
-  integrity sha512-l7WLhIHjhHMtlpyTSltPPAKLpiMwgMD1hXHj59AVUpYRoZP7Fd9NNOSRSvZBCPLpTHPYojgQvSJCoza9zoL7bg==
+"@types/three@^0.137.0":
+  version "0.137.0"
+  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.137.0.tgz#6047e0658262b4de7c464a40288f9071ddd9a6d5"
+  integrity sha512-Xc5EAlfYmgrCLI/VlSVqiRJAtzhWF0Rw2jSq48nqJy+Hcb5sfDOXyfZn1+RNcHyi9l8CeCAXCZygO8IyeOJVEA==
 
 "@zeit/schemas@2.6.0":
   version "2.6.0"
@@ -2165,10 +2165,10 @@ supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-three@^0.136.0:
-  version "0.136.0"
-  resolved "https://registry.yarnpkg.com/three/-/three-0.136.0.tgz#b1504db021b46398ef468aa7849f3dcabb814f50"
-  integrity sha512-+fEMX7nYLz2ZesVP/dyifli5Jf8gR3XPAnFJveQ80aMhibFduzrADnjMbARXh8+W9qLK7rshJCjAIL/6cDxC+A==
+three@^0.137.0:
+  version "0.137.5"
+  resolved "https://registry.yarnpkg.com/three/-/three-0.137.5.tgz#a1e34bedd0412f2d8797112973dfadac78022ce6"
+  integrity sha512-rTyr+HDFxjnN8+N/guZjDgfVxgHptZQpf6xfL/Mo7a5JYIFwK6tAq3bzxYYB4Ae0RosDZlDuP+X5aXDXz+XnHQ==
 
 to-fast-properties@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
- Bump three & @types/three to `r137`
- Make types more flexible so we don't have to match the entire Scene type, just the parts we need.
- Likewise with World
- ['.gitignore'] Add `yarn-error.log`

